### PR TITLE
dev(setup): add absolute import config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,17 @@ module.exports = {
       files: ['**/*.ts', '**/*.tsx'],
       parser: '@typescript-eslint/parser',
       parserOptions: { project: './tsconfig.json' },
-      settings: { react: { version: 'detect' } },
+      settings: { 
+        react: { 
+          version: 'detect' 
+        },
+        'import/resolver': {
+          alias: {
+            map: [['~', '.']],
+            extensions: ['.js', '.ts', '.tsx'],
+          },
+        },
+      },
       env: {
         browser: true,
         node: true,

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  semicolon: true,
+  semi: true,
   trailingComma: 'es5',
   singleQuote: true,
   printWidth: 80,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint": "^7.19.0",
     "eslint-config-airbnb-typescript": "^12.0.0",
     "eslint-config-prettier": "^7.2.0",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.3.1",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Head from 'next/head';
-import styles from '../styles/Home.module.css';
+import styles from '~/styles/Home.module.css';
 
 const Home: React.FC = () => {
   const [, setText] = useState<string>();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"]
+    },
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
# Features

- absolute import config 추가 (prefix: `~`)

```shell
<rootPath>
    |-- pages
        |-- firstDepth
            |-- secondDepth
                |-- somePage.tsx
    |-- components
        |-- someComponent.tsx
```

```typescript
// in <rootPath>/pages/firstDepth/secondDepth/somePage.tsx

/* as is */
import SomeComponent from '../../../components/someComponent';

/* to be */
import SomeComponent from '~/components/someComponent';
```

- pretterrc property name 변경 (semicolon -> semi)